### PR TITLE
tradução para pt_BR

### DIFF
--- a/locales/pt/strings.l20n
+++ b/locales/pt/strings.l20n
@@ -1,0 +1,11 @@
+<welcome "Benvido ao <strong>Firefox OS</strong> Builds. Aqui poderá encontrar versões não oficiais do Firefox OS para diferentes dispositivos criadas pela comunidade.">
+<download "Baixar (não disponível)">
+<devices "Dispositivos">
+<installguide "Guia de instalação</small>">
+<latestversion "Última versão estável: <em>1.3</em>">
+<install "Instalação">
+<staytuned "Fique ligado, detalhes em breve!">
+<about "Sobre">
+<abouttext "Este site foi criado por voluntários e não é parte oficial de nenhum fabricante de dispositivos, operadora ou da Mozilla Corportation. As compilações estão alojadas em servidores de terceiros e são apenas listadas aqui para a comodidade dos usuários.">
+<disclaimer "Renúncia de responsabilidade">
+<disclaimertext "Os membros da equipe do Firefox OS Builds, ou qualquer outra pessoa neste site, não são responsáveis por dispositivos 'brickados', cartões SD mortos, perdade dados ou por você ter sido despedido caso a aplicação de alarme falhe em despertar. Por favor, pesquise antes de instalar se tem alguma dúvida sobre as características das versões que estão nesse site. É SUA decisão fazer estas modificações. É possível que você perca o direito a garantia do fabricante caso altere o hardware ou o software do seu dispositivo.">


### PR DESCRIPTION
Segue a tradução para pt_BR da pasta locales. Acredito que sirva para pt_PT também.
